### PR TITLE
Vs code variable reference classification panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,139 @@
 # Variable Read/Write Reference
 
-<a href="https://marketplace.visualstudio.com/items?itemName=jeremy-hibiki.vscode-variable-rw-reference" target="__blank"><img src="https://img.shields.io/visual-studio-marketplace/v/jeremy-hibiki.vscode-variable-rw-reference.svg?color=eee&amp;label=VS%20Code%20Marketplace&logo=visual-studio-code" alt="Visual Studio Marketplace Version" /></a>
+一个VSCode插件，用于分析变量引用并按读写操作进行分类展示，类似于IntelliJ IDEA的引用查看器。
 
-## Configurations
+## 🌟 功能特性
 
-<!-- configs -->
+- **智能读写分类**: 自动分析变量的引用类型
+  - **读取操作**: `variable`, `obj.property`, `array[index]`
+  - **写入操作**: `variable = value`, 解构赋值等
+  - **读写操作**: `variable++`, `variable += 1`, `variable--` 等
 
-**No data**
+- **灵活的分组模式**:
+  - 按文件分组：先按文件分类，再按读写类型细分
+  - 按类型分组：直接按读、写、读写操作分类
 
-<!-- configs -->
+- **直观的树形视图**: 在侧边栏展示分类后的引用，支持一键跳转到代码位置
 
-## Commands
+- **LSP集成**: 基于VSCode的语言服务提供程序获取准确的引用信息
 
-<!-- commands -->
+## 🚀 使用方法
 
-**No data**
+### 1. 查找引用
+有三种方式启动变量引用分析：
 
-<!-- commands -->
+1. **右键菜单**: 在变量上右键选择 "Find References (R/W)"
+2. **命令面板**: 按 `Ctrl+Shift+P` (Windows/Linux) 或 `Cmd+Shift+P` (Mac)，搜索 "Find References (R/W)"
+3. **选中变量**: 选中变量后使用命令面板执行查找
 
-## License
+### 2. 查看结果
+分析完成后，结果会显示在资源管理器面板的 "Variable References (R/W)" 视图中。
 
-[MIT](./LICENSE.md) License © 2025 [Jeremy Hibiki](https://github.com/jeremy-hibiki)
+#### 按文件分组模式 (默认)
+```
+📁 example.js (15)
+  👁️ Reads (10)
+    ○ Line 6: return count; // 读取操作
+    ○ Line 14: return count * 2; // 读取操作
+    ...
+  ✏️ Writes (2)
+    ● Line 10: count = 0; // 写入操作
+    ● Line 33: count = 10; // 写入操作
+  ⚙️ Read/Write (3)
+    ◉ Line 5: count++; // 读写操作
+    ◉ Line 17: count += 5; // 读写操作
+    ...
+```
+
+#### 按类型分组模式
+```
+👁️ Reads (10)
+  ○ Line 6: return count; // 读取操作 (example.js)
+  ○ Line 14: return count * 2; // 读取操作 (example.js)
+  ...
+✏️ Writes (2)
+  ● Line 10: count = 0; // 写入操作 (example.js)
+  ...
+⚙️ Read/Write (3)
+  ◉ Line 5: count++; // 读写操作 (example.js)
+  ...
+```
+
+### 3. 切换分组模式
+点击视图标题栏的 📋 图标可以在两种分组模式之间切换。
+
+## ⚙️ 配置选项
+
+在VSCode设置中搜索 "Variable R/W Reference" 或手动编辑 `settings.json`：
+
+```json
+{
+  "variableRwReference.autoShowPanel": true,     // 自动显示引用面板
+  "variableRwReference.groupByFile": true        // 按文件分组（false为按类型分组）
+}
+```
+
+## 📝 支持的语言
+
+插件依赖于VSCode的语言服务提供程序 (LSP)，因此支持所有具有LSP支持的语言，包括但不限于：
+
+- JavaScript / TypeScript
+- Python
+- Java
+- C/C++
+- C#
+- Go
+- Rust
+- PHP
+- 等等...
+
+## 🎯 读写识别规则
+
+### 读取操作
+- 变量作为表达式使用：`console.log(variable)`
+- 属性访问：`object.property`
+- 数组访问：`array[index]`
+- 函数参数：`function(variable)`
+- 比较操作：`if (variable > 5)`
+
+### 写入操作
+- 直接赋值：`variable = value`
+- 解构赋值：`const {variable} = object`
+- 参数赋值（在某些上下文中）
+
+### 读写操作
+- 前置递增/递减：`++variable`, `--variable`
+- 后置递增/递减：`variable++`, `variable--`
+- 复合赋值：`variable += 1`, `variable *= 2`, `variable |= flag` 等
+
+## 🔧 开发和贡献
+
+### 环境要求
+- Node.js 16+
+- pnpm
+
+### 构建项目
+```bash
+pnpm install
+pnpm run build
+```
+
+### 开发模式
+```bash
+pnpm run dev
+```
+
+### 测试
+按 `F5` 在VSCode中启动插件调试会话，或使用 `example.js` 文件测试功能。
+
+## 📄 许可证
+
+MIT License - 详见 [LICENSE.md](LICENSE.md)
+
+## 🐛 问题反馈
+
+如果遇到问题或有功能建议，请在 [GitHub Issues](https://github.com/Jeremy-Hibiki/vscode-variable-rw-reference/issues) 中反馈。
+
+---
+
+*让代码导航更智能，让开发更高效！* 🚀

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "private": true,
   "packageManager": "pnpm@10.4.1",
-  "description": "",
+  "description": "VSCode extension to categorize variable references by read/write operations, similar to IntelliJ IDEA's reference viewer",
   "author": "Jeremy Hibiki <JeremyJiang430@outlook.com>",
   "license": "MIT",
   "homepage": "https://github.com/Jeremy-Hibiki/vscode-variable-rw-reference#readme",
@@ -33,11 +33,74 @@
     "onStartupFinished"
   ],
   "contributes": {
-    "commands": [],
+    "commands": [
+      {
+        "command": "variableRwReference.findReferences",
+        "title": "Find References (R/W)",
+        "category": "Variable R/W Reference"
+      },
+      {
+        "command": "variableRwReference.refresh",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "variableRwReference.toggleGrouping",
+        "title": "Toggle Grouping Mode",
+        "icon": "$(list-tree)"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "variableRwReference.findReferences",
+          "when": "editorHasSelection",
+          "group": "navigation@10"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "variableRwReference.refresh",
+          "when": "view == variableRwReference",
+          "group": "navigation"
+        },
+        {
+          "command": "variableRwReference.toggleGrouping",
+          "when": "view == variableRwReference",
+          "group": "navigation"
+        }
+      ]
+    },
+    "views": {
+      "explorer": [
+        {
+          "id": "variableRwReference",
+          "name": "Variable References (R/W)",
+          "when": "variableRwReference.hasReferences"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "variableRwReference",
+        "contents": "No references found.\n[Find References](command:variableRwReference.findReferences)"
+      }
+    ],
     "configuration": {
       "type": "object",
-      "title": "vscode-variable-rw-reference",
-      "properties": {}
+      "title": "Variable R/W Reference",
+      "properties": {
+        "variableRwReference.autoShowPanel": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically show the references panel when finding references"
+        },
+        "variableRwReference.groupByFile": {
+          "type": "boolean", 
+          "default": true,
+          "description": "Group references by file"
+        }
+      }
     }
   },
   "scripts": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,17 @@
-import { defineConfigObject } from 'reactive-vscode'
-import * as Meta from './generated/meta'
+import { defineConfigObject, computed } from 'reactive-vscode'
+import * as vscode from 'vscode'
 
-export const config = defineConfigObject<Meta.ScopedConfigKeyTypeMap>(
-  Meta.scopedConfigs.scope,
-  Meta.scopedConfigs.defaults,
-)
+// 直接使用 vscode.workspace.getConfiguration 来获取配置
+export const config = {
+  get autoShowPanel(): boolean {
+    return vscode.workspace.getConfiguration('variableRwReference').get('autoShowPanel', true)
+  },
+  
+  get groupByFile(): boolean {
+    return vscode.workspace.getConfiguration('variableRwReference').get('groupByFile', true)
+  },
+  
+  set groupByFile(value: boolean) {
+    vscode.workspace.getConfiguration('variableRwReference').update('groupByFile', value, vscode.ConfigurationTarget.Global)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,143 @@
 import { defineExtension } from 'reactive-vscode'
-import { window } from 'vscode'
+import * as vscode from 'vscode'
+import { ReferenceAnalyzer } from './referenceAnalyzer'
+import { ReferenceTreeProvider } from './referenceTreeProvider'
+import { config } from './config'
 
 const { activate, deactivate } = defineExtension(() => {
-  window.showInformationMessage('Hello')
+  const analyzer = new ReferenceAnalyzer()
+  const treeProvider = new ReferenceTreeProvider()
+  
+  // 注册树形视图
+  const treeView = vscode.window.createTreeView('variableRwReference', {
+    treeDataProvider: treeProvider,
+    showCollapseAll: true
+  })
+
+  // 注册查找引用命令
+  const findReferencesCommand = vscode.commands.registerCommand(
+    'variableRwReference.findReferences',
+    async () => {
+      const editor = vscode.window.activeTextEditor
+      if (!editor) {
+        vscode.window.showWarningMessage('没有活动的编辑器')
+        return
+      }
+
+      const document = editor.document
+      const position = editor.selection.active
+      
+      // 获取当前位置的符号
+      const wordRange = document.getWordRangeAtPosition(position)
+      if (!wordRange) {
+        vscode.window.showWarningMessage('请将光标放在变量名上')
+        return
+      }
+      
+      const symbol = document.getText(wordRange)
+      
+      try {
+        // 显示进度提示
+        await vscode.window.withProgress({
+          location: vscode.ProgressLocation.Notification,
+          title: `分析变量 "${symbol}" 的引用...`,
+          cancellable: false
+        }, async (progress) => {
+          progress.report({ increment: 0 })
+          
+          // 分析引用
+          const result = await analyzer.analyzeReferences(document, position, symbol)
+          
+          progress.report({ increment: 50 })
+          
+          // 更新树形视图
+          const groupByFile = config.groupByFile
+          treeProvider.setAnalysisResult(result, groupByFile)
+          
+          progress.report({ increment: 100 })
+          
+          // 设置上下文来显示视图
+          vscode.commands.executeCommand('setContext', 'variableRwReference.hasReferences', result.totalReferences > 0)
+          
+          // 如果配置了自动显示面板，则聚焦到视图
+          if (config.autoShowPanel && result.totalReferences > 0) {
+            // 显示视图面板
+            vscode.commands.executeCommand('workbench.view.explorer')
+          }
+          
+          // 显示结果摘要
+          const { reads, writes, readWrites } = result.groupedByType
+          vscode.window.showInformationMessage(
+            `找到 "${symbol}" 的 ${result.totalReferences} 个引用：${reads.length} 个读取，${writes.length} 个写入，${readWrites.length} 个读写操作`
+          )
+        })
+      } catch (error) {
+        console.error('分析引用时出错:', error)
+        vscode.window.showErrorMessage(`分析引用时出错: ${error instanceof Error ? error.message : String(error)}`)
+      }
+    }
+  )
+
+  // 注册刷新命令
+  const refreshCommand = vscode.commands.registerCommand(
+    'variableRwReference.refresh',
+    () => {
+      treeProvider.refresh()
+      vscode.window.showInformationMessage('引用视图已刷新')
+    }
+  )
+
+  // 注册切换分组模式命令
+  const toggleGroupingCommand = vscode.commands.registerCommand(
+    'variableRwReference.toggleGrouping',
+    () => {
+      const currentGroupByFile = config.groupByFile
+      config.groupByFile = !currentGroupByFile
+      
+      // 如果有分析结果，重新应用分组
+      if (treeProvider['analysisResult']) {
+        treeProvider.setAnalysisResult(treeProvider['analysisResult'], config.groupByFile)
+      }
+      
+      vscode.window.showInformationMessage(
+        `分组模式已切换为: ${config.groupByFile ? '按文件分组' : '按类型分组'}`
+      )
+    }
+  )
+
+  // 监听配置变化
+  const configChangeListener = vscode.workspace.onDidChangeConfiguration(e => {
+    if (e.affectsConfiguration('variableRwReference')) {
+      // 重新应用分析结果（如果有的话）
+      if (treeProvider['analysisResult']) {
+        treeProvider.setAnalysisResult(treeProvider['analysisResult'], config.groupByFile)
+      }
+    }
+  })
+
+  // 注册上下文菜单项（右键菜单）
+  const contextMenuCommand = vscode.commands.registerCommand(
+    'variableRwReference.findReferencesContext',
+    async (uri: vscode.Uri, position: vscode.Position) => {
+      // 打开文档并设置光标位置
+      const document = await vscode.workspace.openTextDocument(uri)
+      const editor = await vscode.window.showTextDocument(document)
+      editor.selection = new vscode.Selection(position, position)
+      
+      // 执行查找引用
+      vscode.commands.executeCommand('variableRwReference.findReferences')
+    }
+  )
+
+  // 清理函数
+  return () => {
+    findReferencesCommand.dispose()
+    refreshCommand.dispose()
+    toggleGroupingCommand.dispose()
+    contextMenuCommand.dispose()
+    configChangeListener.dispose()
+    treeView.dispose()
+  }
 })
 
 export { activate, deactivate }

--- a/src/referenceAnalyzer.ts
+++ b/src/referenceAnalyzer.ts
@@ -1,0 +1,232 @@
+import * as vscode from 'vscode'
+import { VariableReference, ReferenceType, GroupedReferences, FileGroupedReferences, ReferenceAnalysisResult } from './types'
+
+export class ReferenceAnalyzer {
+  
+  /**
+   * 分析变量引用并按读写类型分类
+   */
+  async analyzeReferences(
+    document: vscode.TextDocument, 
+    position: vscode.Position,
+    symbol: string
+  ): Promise<ReferenceAnalysisResult> {
+    // 获取所有引用
+    const references = await this.getAllReferences(document, position)
+    
+    if (!references || references.length === 0) {
+      return {
+        symbol,
+        totalReferences: 0,
+        groupedByType: { reads: [], writes: [], readWrites: [] },
+        groupedByFile: {}
+      }
+    }
+
+    // 分析每个引用的读写类型
+    const analyzedReferences = await Promise.all(
+      references.map(ref => this.analyzeReference(ref, symbol))
+    )
+
+    // 按类型分组
+    const groupedByType = this.groupReferencesByType(analyzedReferences)
+    
+    // 按文件分组
+    const groupedByFile = this.groupReferencesByFile(analyzedReferences)
+
+    return {
+      symbol,
+      totalReferences: analyzedReferences.length,
+      groupedByType,
+      groupedByFile
+    }
+  }
+
+  /**
+   * 获取所有引用位置
+   */
+  private async getAllReferences(
+    document: vscode.TextDocument, 
+    position: vscode.Position
+  ): Promise<vscode.Location[]> {
+    try {
+      const locations = await vscode.commands.executeCommand<vscode.Location[]>(
+        'vscode.executeReferenceProvider',
+        document.uri,
+        position
+      )
+      return locations || []
+    } catch (error) {
+      console.error('Failed to get references:', error)
+      return []
+    }
+  }
+
+  /**
+   * 分析单个引用的读写类型
+   */
+  private async analyzeReference(
+    location: vscode.Location, 
+    symbol: string
+  ): Promise<VariableReference> {
+    try {
+      const document = await vscode.workspace.openTextDocument(location.uri)
+      const line = document.lineAt(location.range.start.line)
+      const context = line.text
+      
+      // 获取符号在行中的位置
+      const symbolStart = location.range.start.character
+      const symbolEnd = location.range.end.character
+      
+      // 分析读写类型
+      const type = this.determineReferenceType(context, symbolStart, symbolEnd, symbol)
+      
+      return {
+        location,
+        isWrite: type === ReferenceType.WRITE || type === ReferenceType.READ_WRITE,
+        context,
+        type
+      }
+    } catch (error) {
+      console.error('Failed to analyze reference:', error)
+      return {
+        location,
+        isWrite: false,
+        context: '',
+        type: ReferenceType.READ
+      }
+    }
+  }
+
+  /**
+   * 确定引用类型（读/写/读写）
+   */
+  private determineReferenceType(
+    context: string, 
+    symbolStart: number, 
+    symbolEnd: number, 
+    symbol: string
+  ): ReferenceType {
+    const beforeSymbol = context.substring(0, symbolStart).trim()
+    const afterSymbol = context.substring(symbolEnd).trim()
+    
+    // 检查是否是写操作
+    const isWrite = this.isWriteOperation(beforeSymbol, afterSymbol, context, symbolStart, symbolEnd)
+    
+    // 检查是否是读写操作（如 ++variable, variable++, variable += 1）
+    const isReadWrite = this.isReadWriteOperation(beforeSymbol, afterSymbol, context, symbolStart, symbolEnd)
+    
+    if (isReadWrite) {
+      return ReferenceType.READ_WRITE
+    } else if (isWrite) {
+      return ReferenceType.WRITE
+    } else {
+      return ReferenceType.READ
+    }
+  }
+
+  /**
+   * 检查是否是写操作
+   */
+  private isWriteOperation(
+    beforeSymbol: string, 
+    afterSymbol: string, 
+    context: string,
+    symbolStart: number,
+    symbolEnd: number
+  ): boolean {
+    // 赋值操作
+    if (afterSymbol.startsWith('=') && !afterSymbol.startsWith('==') && !afterSymbol.startsWith('===')) {
+      return true
+    }
+    
+    // 解构赋值
+    if (beforeSymbol.includes('=') && (beforeSymbol.includes('{') || beforeSymbol.includes('['))) {
+      return true
+    }
+    
+    // 函数参数（可能是输出参数）
+    if (beforeSymbol.includes('(') && afterSymbol.includes(')')) {
+      // 这里可以进一步分析是否是输出参数
+      return false
+    }
+    
+    // 对象属性赋值
+    if (afterSymbol.match(/^\s*\.\s*\w+\s*=/)) {
+      return false // 这种情况下symbol本身是读取，属性是写入
+    }
+    
+    return false
+  }
+
+  /**
+   * 检查是否是读写操作
+   */
+  private isReadWriteOperation(
+    beforeSymbol: string, 
+    afterSymbol: string, 
+    context: string,
+    symbolStart: number,
+    symbolEnd: number
+  ): boolean {
+    // 前置递增/递减
+    if (beforeSymbol.endsWith('++') || beforeSymbol.endsWith('--')) {
+      return true
+    }
+    
+    // 后置递增/递减
+    if (afterSymbol.startsWith('++') || afterSymbol.startsWith('--')) {
+      return true
+    }
+    
+    // 复合赋值操作符
+    const compoundOperators = ['+=', '-=', '*=', '/=', '%=', '&=', '|=', '^=', '<<=', '>>=', '>>>=']
+    for (const op of compoundOperators) {
+      if (afterSymbol.startsWith(op)) {
+        return true
+      }
+    }
+    
+    return false
+  }
+
+  /**
+   * 按类型分组引用
+   */
+  private groupReferencesByType(references: VariableReference[]): GroupedReferences {
+    return {
+      reads: references.filter(ref => ref.type === ReferenceType.READ),
+      writes: references.filter(ref => ref.type === ReferenceType.WRITE),
+      readWrites: references.filter(ref => ref.type === ReferenceType.READ_WRITE)
+    }
+  }
+
+  /**
+   * 按文件分组引用
+   */
+  private groupReferencesByFile(references: VariableReference[]): FileGroupedReferences {
+    const grouped: FileGroupedReferences = {}
+    
+    for (const ref of references) {
+      const filePath = ref.location.uri.fsPath
+      
+      if (!grouped[filePath]) {
+        grouped[filePath] = { reads: [], writes: [], readWrites: [] }
+      }
+      
+      switch (ref.type) {
+        case ReferenceType.READ:
+          grouped[filePath].reads.push(ref)
+          break
+        case ReferenceType.WRITE:
+          grouped[filePath].writes.push(ref)
+          break
+        case ReferenceType.READ_WRITE:
+          grouped[filePath].readWrites.push(ref)
+          break
+      }
+    }
+    
+    return grouped
+  }
+}

--- a/src/referenceTreeProvider.ts
+++ b/src/referenceTreeProvider.ts
@@ -1,0 +1,260 @@
+import * as vscode from 'vscode'
+import * as path from 'path'
+import { VariableReference, ReferenceType, ReferenceAnalysisResult } from './types'
+
+export class ReferenceTreeItem extends vscode.TreeItem {
+  public parentFilePath?: string  // 用于追踪父文件路径
+  
+  constructor(
+    public readonly label: string,
+    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public readonly reference?: VariableReference,
+    public readonly count?: number,
+    public readonly type?: 'root' | 'category' | 'file' | 'reference',
+    parentFilePath?: string
+  ) {
+    super(label, collapsibleState)
+    this.parentFilePath = parentFilePath
+    
+    this.tooltip = this.getTooltip()
+    this.iconPath = this.getIcon()
+    this.contextValue = type
+    
+    if (reference) {
+      this.command = {
+        command: 'vscode.open',
+        title: 'Open',
+        arguments: [
+          reference.location.uri,
+          {
+            selection: reference.location.range,
+            viewColumn: vscode.ViewColumn.One
+          }
+        ]
+      }
+    }
+  }
+
+  private getTooltip(): string {
+    if (this.reference) {
+      return `${this.reference.context}\nFile: ${this.reference.location.uri.fsPath}\nLine: ${this.reference.location.range.start.line + 1}`
+    }
+    if (this.count !== undefined) {
+      return `${this.count} reference${this.count !== 1 ? 's' : ''}`
+    }
+    return this.label
+  }
+
+  private getIcon(): vscode.ThemeIcon | undefined {
+    switch (this.type) {
+      case 'category':
+        if (this.label.includes('Read')) return new vscode.ThemeIcon('eye')
+        if (this.label.includes('Write')) return new vscode.ThemeIcon('edit')
+        if (this.label.includes('Read/Write')) return new vscode.ThemeIcon('symbol-operator')
+        break
+      case 'file':
+        return vscode.ThemeIcon.File
+      case 'reference':
+        if (this.reference?.type === ReferenceType.READ) return new vscode.ThemeIcon('circle-outline')
+        if (this.reference?.type === ReferenceType.WRITE) return new vscode.ThemeIcon('circle-filled')
+        if (this.reference?.type === ReferenceType.READ_WRITE) return new vscode.ThemeIcon('circle-large-filled')
+        break
+    }
+    return undefined
+  }
+}
+
+export class ReferenceTreeProvider implements vscode.TreeDataProvider<ReferenceTreeItem> {
+  private _onDidChangeTreeData: vscode.EventEmitter<ReferenceTreeItem | undefined | null | void> = new vscode.EventEmitter<ReferenceTreeItem | undefined | null | void>()
+  readonly onDidChangeTreeData: vscode.Event<ReferenceTreeItem | undefined | null | void> = this._onDidChangeTreeData.event
+
+  private analysisResult: ReferenceAnalysisResult | undefined
+  private groupByFile: boolean = true
+  private fileItemsMap = new Map<string, ReferenceTreeItem>()
+
+  constructor() {}
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire()
+  }
+
+  setAnalysisResult(result: ReferenceAnalysisResult, groupByFile: boolean = true): void {
+    this.analysisResult = result
+    this.groupByFile = groupByFile
+    this.refresh()
+  }
+
+  clear(): void {
+    this.analysisResult = undefined
+    this.refresh()
+  }
+
+  getTreeItem(element: ReferenceTreeItem): vscode.TreeItem {
+    return element
+  }
+
+  getChildren(element?: ReferenceTreeItem): Thenable<ReferenceTreeItem[]> {
+    if (!this.analysisResult) {
+      return Promise.resolve([])
+    }
+
+    if (!element) {
+      // 根节点
+      return Promise.resolve(this.getRootChildren())
+    }
+
+    return Promise.resolve(this.getElementChildren(element))
+  }
+
+  private getRootChildren(): ReferenceTreeItem[] {
+    if (!this.analysisResult) return []
+
+    const result = this.analysisResult
+    const items: ReferenceTreeItem[] = []
+    this.fileItemsMap.clear()
+
+    if (this.groupByFile) {
+      // 按文件分组
+      Object.entries(result.groupedByFile).forEach(([filePath, groupedRefs]) => {
+        const fileName = path.basename(filePath)
+        const totalCount = groupedRefs.reads.length + groupedRefs.writes.length + groupedRefs.readWrites.length
+        
+        const fileItem = new ReferenceTreeItem(
+          `${fileName} (${totalCount})`,
+          vscode.TreeItemCollapsibleState.Expanded,
+          undefined,
+          totalCount,
+          'file'
+        )
+        fileItem.resourceUri = vscode.Uri.file(filePath)
+        this.fileItemsMap.set(filePath, fileItem)
+        items.push(fileItem)
+      })
+    } else {
+      // 按类型分组
+      const { reads, writes, readWrites } = result.groupedByType
+      
+      if (reads.length > 0) {
+        items.push(new ReferenceTreeItem(
+          `Reads (${reads.length})`,
+          vscode.TreeItemCollapsibleState.Expanded,
+          undefined,
+          reads.length,
+          'category'
+        ))
+      }
+      
+      if (writes.length > 0) {
+        items.push(new ReferenceTreeItem(
+          `Writes (${writes.length})`,
+          vscode.TreeItemCollapsibleState.Expanded,
+          undefined,
+          writes.length,
+          'category'
+        ))
+      }
+      
+      if (readWrites.length > 0) {
+        items.push(new ReferenceTreeItem(
+          `Read/Write (${readWrites.length})`,
+          vscode.TreeItemCollapsibleState.Expanded,
+          undefined,
+          readWrites.length,
+          'category'
+        ))
+      }
+    }
+
+    return items
+  }
+
+  private getElementChildren(element: ReferenceTreeItem): ReferenceTreeItem[] {
+    if (!this.analysisResult) return []
+
+    const result = this.analysisResult
+
+    if (this.groupByFile && element.type === 'file') {
+      // 文件下的类型分组
+      const filePath = element.resourceUri?.fsPath
+      if (!filePath || !result.groupedByFile[filePath]) return []
+
+      const groupedRefs = result.groupedByFile[filePath]
+      const items: ReferenceTreeItem[] = []
+
+      if (groupedRefs.reads.length > 0) {
+        items.push(new ReferenceTreeItem(
+          `Reads (${groupedRefs.reads.length})`,
+          vscode.TreeItemCollapsibleState.Expanded,
+          undefined,
+          groupedRefs.reads.length,
+          'category',
+          filePath
+        ))
+      }
+
+      if (groupedRefs.writes.length > 0) {
+        items.push(new ReferenceTreeItem(
+          `Writes (${groupedRefs.writes.length})`,
+          vscode.TreeItemCollapsibleState.Expanded,
+          undefined,
+          groupedRefs.writes.length,
+          'category',
+          filePath
+        ))
+      }
+
+      if (groupedRefs.readWrites.length > 0) {
+        items.push(new ReferenceTreeItem(
+          `Read/Write (${groupedRefs.readWrites.length})`,
+          vscode.TreeItemCollapsibleState.Expanded,
+          undefined,
+          groupedRefs.readWrites.length,
+          'category',
+          filePath
+        ))
+      }
+
+      return items
+    }
+
+    if (element.type === 'category') {
+      // 类型分组下的具体引用
+      let references: VariableReference[] = []
+
+      if (this.groupByFile) {
+        // 在文件分组模式下，使用parentFilePath来找到对应文件的引用
+        if (element.parentFilePath) {
+          const groupedRefs = result.groupedByFile[element.parentFilePath]
+          if (groupedRefs) {
+            if (element.label.includes('Reads')) references = groupedRefs.reads
+            else if (element.label.includes('Writes')) references = groupedRefs.writes
+            else if (element.label.includes('Read/Write')) references = groupedRefs.readWrites
+          }
+        }
+      } else {
+        // 在类型分组模式下
+        if (element.label.includes('Reads')) references = result.groupedByType.reads
+        else if (element.label.includes('Writes')) references = result.groupedByType.writes
+        else if (element.label.includes('Read/Write')) references = result.groupedByType.readWrites
+      }
+
+      return references.map(ref => {
+        const line = ref.location.range.start.line + 1
+        const context = ref.context?.trim() || ''
+        const preview = context.length > 60 ? context.substring(0, 60) + '...' : context
+        
+        return new ReferenceTreeItem(
+          `Line ${line}: ${preview}`,
+          vscode.TreeItemCollapsibleState.None,
+          ref,
+          undefined,
+          'reference'
+        )
+      })
+    }
+
+    return []
+  }
+
+
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,31 @@
+import * as vscode from 'vscode'
+
+export interface VariableReference {
+  location: vscode.Location
+  isWrite: boolean
+  context?: string // 上下文代码片段
+  type: ReferenceType
+}
+
+export enum ReferenceType {
+  READ = 'read',
+  WRITE = 'write',
+  READ_WRITE = 'readwrite' // 比如 obj.prop++ 这种既读又写的情况
+}
+
+export interface GroupedReferences {
+  reads: VariableReference[]
+  writes: VariableReference[]
+  readWrites: VariableReference[]
+}
+
+export interface FileGroupedReferences {
+  [filePath: string]: GroupedReferences
+}
+
+export interface ReferenceAnalysisResult {
+  symbol: string
+  totalReferences: number
+  groupedByType: GroupedReferences
+  groupedByFile: FileGroupedReferences
+}


### PR DESCRIPTION
Adds a VSCode extension to categorize variable references by read/write operations and display them in a side panel, similar to IntelliJ IDEA's reference viewer.

---
<a href="https://cursor.com/background-agent?bcId=bc-14afa2ec-e9e6-46c5-99be-616e7d22f69c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14afa2ec-e9e6-46c5-99be-616e7d22f69c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

